### PR TITLE
Reduce transparency for debug- and diff background

### DIFF
--- a/src/nord-intellij-idea-syntax.icls
+++ b/src/nord-intellij-idea-syntax.icls
@@ -28,6 +28,7 @@ IntelliJ IDEA
     <option name="CONSOLE_BACKGROUND_KEY" value="2e3440" />
     <option name="DELETED_LINES_COLOR" value="bf616a" />
     <option name="DOCUMENTATION_COLOR" value="434c5e" />
+    <option name="ERROR_HINT" value="434c5e" />
     <option name="FILESTATUS_ADDED" value="a3be8c" />
     <option name="FILESTATUS_DELETED" value="bf616a" />
     <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="4c566a" />
@@ -51,10 +52,12 @@ IntelliJ IDEA
     <option name="HTML_TAG_TREE_LEVEL4" value="" />
     <option name="HTML_TAG_TREE_LEVEL5" value="" />
     <option name="INDENT_GUIDE" value="4c566a" />
+    <option name="INFORMATION_HINT" value="434c5e" />
     <option name="LINE_NUMBERS_COLOR" value="4c566a" />
     <option name="METHOD_SEPARATORS_COLOR" value="d8dee9" />
     <option name="MODIFIED_LINES_COLOR" value="ebcb8b" />
     <option name="NOTIFICATION_BACKGROUND" value="d8dee9" />
+    <option name="QUESTION_HINT" value="434c5e" />
     <option name="RECURSIVE_CALL_ATTRIBUTES" value="" />
     <option name="RIGHT_MARGIN_COLOR" value="4c566a" />
     <option name="SELECTED_TEARLINE_COLOR" value="434c5e" />
@@ -709,28 +712,28 @@ IntelliJ IDEA
     <option name="DIFF_CONFLICT">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="5e81ac" />
+        <option name="BACKGROUND" value="41536b" />
         <option name="ERROR_STRIPE_COLOR" value="5e81ac" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="bf616a" />
+        <option name="BACKGROUND" value="684651" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="a3be8c" />
+        <option name="BACKGROUND" value="5d6b5e" />
         <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="ebcb8b" />
+        <option name="BACKGROUND" value="7a705e" />
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>
@@ -781,7 +784,7 @@ IntelliJ IDEA
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="81a1c1" />
+        <option name="BACKGROUND" value="41536b" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">


### PR DESCRIPTION
> Closes #24
Related to #10

The background colors of the debugging- and diff views were too bright making the text unreadable. This PR increases the transparency of the colors to provide a better legibility.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/31133249-3a7664a4-a85f-11e7-931b-f3175893f1fc.png"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/31133259-400eabce-a85f-11e7-8ba3-0408c3ccd223.png"/></p>
