### PR TITLE
Remove background from identifier under caret

### DIFF
--- a/src/nord-intellij-idea-syntax.icls
+++ b/src/nord-intellij-idea-syntax.icls
@@ -979,7 +979,6 @@ IntelliJ IDEA
     </option>
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="434c5e" />
         <option name="EFFECT_COLOR" value="88c0d0" />
       </value>
     </option>
@@ -1718,7 +1717,6 @@ IntelliJ IDEA
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="434c5e" />
         <option name="EFFECT_COLOR" value="88c0d0" />
       </value>
     </option>


### PR DESCRIPTION
> Closes #26
Related to #10

Previews with the automatic highlighting on the left side and with a selection on the right side.

<p align="center"><strong>Before</strong><br><img src="https://user-images.githubusercontent.com/7836623/31134633-f36df0be-a862-11e7-8662-be190827fbb4.png"/><br><strong>After</strong><br><img src="https://user-images.githubusercontent.com/7836623/31134652-05e9583c-a863-11e7-96ab-3c81f394034e.png"/></p>